### PR TITLE
[WIP] tophat2-{pe,se}.cwl をまとめる

### DIFF
--- a/tools/tophat2/tophat2.cwl
+++ b/tools/tophat2/tophat2.cwl
@@ -1,0 +1,48 @@
+cwlVersion: v1.0
+class: CommandLineTool
+hints:
+  DockerRequirement:
+    dockerPull: nasuno/tophat2:2.0.9
+baseCommand: tophat2
+
+inputs:
+  process:
+    type: int?
+    inputBinding:
+      prefix: -p
+      position: 1
+  gtf:
+    type: File
+    inputBinding:
+      prefix: -G
+      position: 2
+  gi:
+    type: File
+    inputBinding:
+      position: 3
+  fastq:
+    type:
+      - type: record
+        label: single end
+        fields:
+          fq:
+            type: File
+            inputBinding:
+              position: 4
+      - type: record
+        label: pair end
+        fields:
+          fq1:
+            type: File
+            inputBinding:
+              position: 4
+          fq2:
+            type: File
+            inputBinding:
+              position: 5
+arguments: ["-o", "/var/spool/cwl"]
+outputs:
+  tophat2_bam:
+    type: File
+    outputBinding:
+      glob: "accepted_hits.bam"

--- a/tools/tophat2/tophat2.cwl
+++ b/tools/tophat2/tophat2.cwl
@@ -20,6 +20,12 @@ inputs:
     type: File
     inputBinding:
       position: 3
+  read_layout:
+    type:
+      type: enum
+      symbols:
+        - single end
+        - pair end
   fastq:
     type:
       - type: record
@@ -29,6 +35,13 @@ inputs:
             type: File
             inputBinding:
               position: 4
+              valueFrom: |
+                ${
+                  if (inputs.read_layout != "single end") {
+                    throw new Error('A parameter "fq" is valid if "read_layout" is "single end"')
+                  }
+                  return self
+                }
       - type: record
         label: pair end
         fields:
@@ -36,6 +49,13 @@ inputs:
             type: File
             inputBinding:
               position: 4
+              valueFrom: |
+                ${
+                  if (inputs.read_layout != "pair end") {
+                    throw new Error('A parameter "fq1" is valid if "read_layout" is "pair end"')
+                  }
+                  return self
+                }
           fq2:
             type: File
             inputBinding:


### PR DESCRIPTION
現状はペアエンド・シングルエンドで別の CWL を使っていますが、record 型を使えば一つにまとめられます。
まとめても複雑度はほとんど上がらないので PR にしました。

workflow/Tophat2Workflow*.cwl などの修正が終わっていないため、WIP にしています。
問題なければ他のも修正します。

- ペアエンド版入力サンプル
```yaml
gtf:
  class: File
  location: hg19.gtf
gi:
  class: File
  location: hg19.fa
fastq:
  fq1:
    class: File
    location: fq1.fastq
  fq2:
    class: File
    location: fq2.fastq
```

- シングルエンド版入力サンプル
```yaml
gtf:
  class: File
  location: hg19.gtf
gi:
  class: File
  location: hg19.fa
fastq:
  fq:
    class: File
    location: fq.fastq
```