### PR TITLE
Replace /var/spool/cwl with portable reference

### DIFF
--- a/tools/cufflinks/cufflinks.cwl
+++ b/tools/cufflinks/cufflinks.cwl
@@ -4,8 +4,6 @@ hints:
   DockerRequirement:
     dockerPull: nasuno/cufflinks:2.2.1
 baseCommand: cufflinks
-requirements:
-  - class: InlineJavascriptRequirement
 inputs:
   process:
     type: int?
@@ -21,7 +19,9 @@ inputs:
     type: File
     inputBinding:
       position: 3
-arguments: ["-o", "/var/spool/cwl"]
+arguments:
+  - prefix: -o
+    valueFrom: $(runtime.outdir)
 outputs:
   cufflinks_result:
     type:

--- a/tools/express/express.cwl
+++ b/tools/express/express.cwl
@@ -3,8 +3,6 @@ class: CommandLineTool
 hints:
   DockerRequirement:
     dockerPull: yyabuki/express:1.5.1
-requirements:
-  - class: InlineJavascriptRequirement
 baseCommand: express
 inputs:
   reference:
@@ -15,7 +13,9 @@ inputs:
     type: File 
     inputBinding:
       position: 2
-arguments: ["-o", "/var/spool/cwl"]
+arguments:
+  - prefix: -o
+    valueFrom: $(runtime.outdir)
 outputs:
   express_result:
     type:

--- a/tools/tophat2/tophat2-pe.cwl
+++ b/tools/tophat2/tophat2-pe.cwl
@@ -28,7 +28,9 @@ inputs:
     type: File
     inputBinding:
       position: 5
-arguments: ["-o", "/var/spool/cwl"]
+arguments:
+  - prefix: -o
+    valueFrom: $(runtime.outdir)
 outputs:
   tophat2_bam:
     type: File

--- a/tools/tophat2/tophat2-se.cwl
+++ b/tools/tophat2/tophat2-se.cwl
@@ -24,7 +24,9 @@ inputs:
     type: File
     inputBinding:
       position: 4
-arguments: ["-o", "/var/spool/cwl"]
+arguments:
+  - prefix: -o
+    valueFrom: $(runtime.outdir)
 outputs:
   tophat2_bam:
     type: File

--- a/workflows/assembler/assembler-version.cwl
+++ b/workflows/assembler/assembler-version.cwl
@@ -6,7 +6,7 @@ hints:
     dockerPull: DOCKER_NAME # (e.g. yyabuki/docker-idba)
 
 inputs: []
-arguments: ["version", "/var/spool/cwl"]
+arguments: ["version", $(runtime.outdir)]
 outputs:
   version_file:
     type: File


### PR DESCRIPTION
`/var/spool/cwl` is not part of the CWL v1.x standards. See
https://github.com/common-workflow-language/common-workflow-language/issues/674
for a discussion.