### PR TITLE
Replace `sed -r` with `sed -E`

### DIFF
--- a/tools/hisat2/mapping/paired_end/test/hisat2_pe.sh
+++ b/tools/hisat2/mapping/paired_end/test/hisat2_pe.sh
@@ -46,7 +46,7 @@ config_yaml_paired_end(){
   local idx_basename=$(basename ${INDEX_FILE_PATH} | sed 's:\..*$::g')
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_INDEX_DIR_PATH_:${idx_basedir}:" \
     -e "s:_INDEX_BASENAME_:${idx_basename}:" \

--- a/tools/hisat2/mapping/single_end/test/hisat2_se.sh
+++ b/tools/hisat2/mapping/single_end/test/hisat2_se.sh
@@ -40,7 +40,7 @@ config_yaml_single_end(){
   local idx_basename=$(basename ${INDEX_FILE_PATH} | sed 's:\..*$::g')
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_INDEX_DIR_PATH_:${idx_basedir}:" \
     -e "s:_INDEX_BASENAME_:${idx_basename}:" \

--- a/tools/kallisto/quant/paired_end/test/kallisto_quanto_pe.sh
+++ b/tools/kallisto/quant/paired_end/test/kallisto_quanto_pe.sh
@@ -50,7 +50,7 @@ config_yaml_single_end(){
   local yaml_path="${1}"
   local fpath="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_INDEX_FILE_PATH_:${INDEX_FILE_PATH}:" \
     -e "s:_FASTQ_PATH_:${fpath}:" \
@@ -66,7 +66,7 @@ config_yaml_paired_end(){
 
   cp "${YAML_TMP_PATH}" "${yaml_path}.buk"
   cat "${yaml_path}.buk" | \
-    sed -r \
+    sed -E \
       -e "s:_INDEX_FILE_PATH_:${INDEX_FILE_PATH}:" \
       -e "s:_NTHREADS_:${NCPUS}:" \
       -e "s#_FASTQ_PATH_#${path_fwd}@  - class: File@    path: ${path_rev}#" \

--- a/tools/kallisto/quant/single_end/test/kallisto_quant_se.sh
+++ b/tools/kallisto/quant/single_end/test/kallisto_quant_se.sh
@@ -50,7 +50,7 @@ config_yaml_single_end(){
   local yaml_path="${1}"
   local fpath="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_INDEX_FILE_PATH_:${INDEX_FILE_PATH}:" \
     -e "s:_FASTQ_PATH_:${fpath}:" \
@@ -66,7 +66,7 @@ config_yaml_paired_end(){
 
   cp "${YAML_TMP_PATH}" "${yaml_path}.buk"
   cat "${yaml_path}.buk" | \
-    sed -r \
+    sed -E \
       -e "s:_INDEX_FILE_PATH_:${INDEX_FILE_PATH}:" \
       -e "s:_NTHREADS_:${NCPUS}:" \
       -e "s#_FASTQ_PATH_#${path_fwd}@  - class: File@    path: ${path_rev}#" \

--- a/tools/rsem/calculate-expression/paired_end/test/rsem-calculate-expression_pe.sh
+++ b/tools/rsem/calculate-expression/paired_end/test/rsem-calculate-expression_pe.sh
@@ -46,7 +46,7 @@ config_yaml_paired_end(){
   local idx_basename=$(basename ${INDEX_FILE_PATH} | sed 's:\..*$::g')
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_PATH_TO_INDEX_DIR_:${idx_basedir}:" \
     -e "s:_RSEM_INDEX_PREFIX_:${idx_basename}:" \

--- a/tools/sailfish/quant/paired_end/test/sailfish_quant_pe.sh
+++ b/tools/sailfish/quant/paired_end/test/sailfish_quant_pe.sh
@@ -43,7 +43,7 @@ config_yaml_paired_end(){
   local path_rev="$(echo "${path_fwd}" | sed 's:_1.fastq:_2.fastq:')"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_PATH_TO_SAILFISH_INDEX_DIR_:${INDEX_DIR_PATH}:" \
     -e "s:_PATH_TO_FORWARD_FASTQ_:${path_fwd}:" \

--- a/tools/sailfish/quant/single_end/test/sailfish_quant_se.sh
+++ b/tools/sailfish/quant/single_end/test/sailfish_quant_se.sh
@@ -37,7 +37,7 @@ config_yaml_single_end(){
   local fpath="${2}"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_PATH_TO_SAILFISH_INDEX_DIR_:${INDEX_DIR_PATH}:" \
     -e "s:_PATH_TO_FASTQ_:${fpath}:" \

--- a/tools/salmon/quant/paired_end/test/salmon_quant_pe.sh
+++ b/tools/salmon/quant/paired_end/test/salmon_quant_pe.sh
@@ -43,7 +43,7 @@ config_yaml_paired_end(){
   local path_rev="$(echo "${path_fwd}" | sed 's:_1.fastq:_2.fastq:')"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_PATH_TO_SALMON_INDEX_DIR_:${INDEX_DIR_PATH}:" \
     -e "s:_PATH_TO_FORWARD_FASTQ_:${path_fwd}:" \

--- a/tools/salmon/quant/single_end/test/salmon_quant_se.sh
+++ b/tools/salmon/quant/single_end/test/salmon_quant_se.sh
@@ -37,7 +37,7 @@ config_yaml_single_end(){
   local fpath="${2}"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_PATH_TO_SALMON_INDEX_DIR_:${INDEX_DIR_PATH}:" \
     -e "s:_PATH_TO_FASTQ_:${fpath}:" \

--- a/tools/star/mapping/paired_end/test/star_mapping_pe.sh
+++ b/tools/star/mapping/paired_end/test/star_mapping_pe.sh
@@ -37,7 +37,7 @@ config_yaml(){
   local fpath="${2}"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_PATH_TO_INDEX_DIR_:${INDEX_DIR_PATH}:" \

--- a/tools/star/mapping/single_end/test/star_mapping_se.sh
+++ b/tools/star/mapping/single_end/test/star_mapping_se.sh
@@ -37,7 +37,7 @@ config_yaml(){
   local fpath="${2}"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_PATH_TO_INDEX_DIR_:${INDEX_DIR_PATH}:" \

--- a/tools/star/mapping_genomeLoad/test/star_load.sh
+++ b/tools/star/mapping_genomeLoad/test/star_load.sh
@@ -37,7 +37,7 @@ config_yaml(){
   local fpath="${2}"
 
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_PATH_TO_INDEX_DIR_:${INDEX_DIR_PATH}:" \

--- a/workflows/hisat2-cufflinks/paired_end/test/hisat2-cufflinks_wf_pe.sh
+++ b/workflows/hisat2-cufflinks/paired_end/test/hisat2-cufflinks_wf_pe.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${HISAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${HISAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/hisat2-cufflinks/single_end/test/hisat2-cufflinks_wf_se.sh
+++ b/workflows/hisat2-cufflinks/single_end/test/hisat2-cufflinks_wf_se.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${HISAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${HISAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/hisat2-eXpress/paired_end/test/hisat2-eXpress_wf_pe.sh
+++ b/workflows/hisat2-eXpress/paired_end/test/hisat2-eXpress_wf_pe.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${HISAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${HISAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/hisat2-eXpress/single_end/test/hisat2-eXpress_wf_se.sh
+++ b/workflows/hisat2-eXpress/single_end/test/hisat2-eXpress_wf_se.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${HISAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${HISAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/hisat2-stringtie/paired_end/test/hisat2-stringtie_wf_pe.sh
+++ b/workflows/hisat2-stringtie/paired_end/test/hisat2-stringtie_wf_pe.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${HISAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${HISAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/hisat2-stringtie/single_end/test/hisat2-stringtie_wf_se.sh
+++ b/workflows/hisat2-stringtie/single_end/test/hisat2-stringtie_wf_se.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${HISAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${HISAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/kallisto/paired_end/test/kallisto_wf_pe.sh
+++ b/workflows/kallisto/paired_end/test/kallisto_wf_pe.sh
@@ -49,7 +49,7 @@ config_yaml(){
   local yaml_path="${1}"
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/kallisto/single_end/test/kallisto_wf_se.sh
+++ b/workflows/kallisto/single_end/test/kallisto_wf_se.sh
@@ -50,7 +50,7 @@ config_yaml(){
   local yaml_path="${1}"
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/sailfish/paired_end/test/sailfish_wf_pe.sh
+++ b/workflows/sailfish/paired_end/test/sailfish_wf_pe.sh
@@ -48,7 +48,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/sailfish/single_end/test/sailfish_wf_se.sh
+++ b/workflows/sailfish/single_end/test/sailfish_wf_se.sh
@@ -48,7 +48,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/salmon/paired_end/test/salmon_wf_pe.sh
+++ b/workflows/salmon/paired_end/test/salmon_wf_pe.sh
@@ -48,7 +48,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/salmon/single_end/test/salmon_wf_se.sh
+++ b/workflows/salmon/single_end/test/salmon_wf_se.sh
@@ -48,7 +48,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/star-cufflinks/paired_end/test/star-cufflinks_wf_pe.sh
+++ b/workflows/star-cufflinks/paired_end/test/star-cufflinks_wf_pe.sh
@@ -50,7 +50,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/star-cufflinks/single_end/test/star-cufflinks_wf_se.sh
+++ b/workflows/star-cufflinks/single_end/test/star-cufflinks_wf_se.sh
@@ -50,7 +50,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/star-eXpress/paired_end/test/star-eXpress_wf_pe.sh
+++ b/workflows/star-eXpress/paired_end/test/star-eXpress_wf_pe.sh
@@ -35,7 +35,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/star-eXpress/single_end/test/star-eXpress_wf_se.sh
+++ b/workflows/star-eXpress/single_end/test/star-eXpress_wf_se.sh
@@ -35,7 +35,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_IDS_:${id}:" \

--- a/workflows/star-rsem/paired_end/test/star-rsem_wf_pe.sh
+++ b/workflows/star-rsem/paired_end/test/star-rsem_wf_pe.sh
@@ -51,7 +51,7 @@ config_yaml(){
   local rsem_idx_basedir=$(readlink $(dirname ${RSEM_INDEX_FILE_PATH}))
   local rsem_idx_prefix=$(basename ${RSEM_INDEX_FILE_PATH} | sed 's:\..*$::')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/star-rsem/single_end/test/star-rsem_wf_se.sh
+++ b/workflows/star-rsem/single_end/test/star-rsem_wf_se.sh
@@ -51,7 +51,7 @@ config_yaml(){
   local rsem_idx_basedir=$(readlink $(dirname ${RSEM_INDEX_FILE_PATH}))
   local rsem_idx_prefix=$(basename ${RSEM_INDEX_FILE_PATH} | sed 's:\..*$::')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/star-stringtie/paired_end/test/star-stringtie_wf_pe.sh
+++ b/workflows/star-stringtie/paired_end/test/star-stringtie_wf_pe.sh
@@ -50,7 +50,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/star-stringtie/single_end/test/star-stringtie_wf_se.sh
+++ b/workflows/star-stringtie/single_end/test/star-stringtie_wf_se.sh
@@ -50,7 +50,7 @@ config_yaml(){
   local id="${2}"
   cp "${YAML_TMP_PATH}" "${yaml_path}"
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/tophat2-cufflinks/paired_end/test/tophat2-cufflinks_wf_pe.sh
+++ b/workflows/tophat2-cufflinks/paired_end/test/tophat2-cufflinks_wf_pe.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${TOPHAT2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${TOPHAT2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \

--- a/workflows/tophat2-cufflinks/single_end/test/tophat2-cufflinks_wf_se.sh
+++ b/workflows/tophat2-cufflinks/single_end/test/tophat2-cufflinks_wf_se.sh
@@ -53,7 +53,7 @@ config_yaml(){
   local idx_basedir=$(dirname ${BOWTIE2_INDEX_FILE_PATH})
   local idx_basename=$(basename ${BOWTIE2_INDEX_FILE_PATH} | sed 's:\..*$::g')
 
-  sed -r \
+  sed -E \
     -i.buk \
     -e "s:_NTHREADS_:${NCPUS}:" \
     -e "s:_RUN_ID_:${id}:" \


### PR DESCRIPTION
Several scripts use `sed -r` to use extended regular expressions.
However, this option is not available in BSD sed.
Also GNU sed recommends to use `-E` option instead of `-r` option:

```console
$ sed
...
  -E, -r, --regexp-extended
                 use extended regular expressions in the script
                 (for portability use POSIX -E).
...
```

This request just replaces `sed -r` with `sed -E` in the scripts.
